### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/brian978/read-in-short/security/code-scanning/1](https://github.com/brian978/read-in-short/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow:
- `contents: read` is required to access the repository contents.
- `packages: read` may be required for dependency installation.
- `actions: read` is needed for interacting with GitHub Actions artifacts.
- `issues: write` or `pull-requests: write` is not required since the workflow does not interact with issues or pull requests.
- `id-token: write` is not required since the workflow does not use OpenID Connect tokens.

The permissions block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
