### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL scheme check

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -53,16 +53,9 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         // Remove javascript: URLs
-        if ((attrName === 'href' || attrName === 'src') &&
-            (attributes[j].value.toLowerCase().
-                trim().
-                startsWith('javascript:') ||
-             attributes[j].value.toLowerCase().
-                trim().
-                startsWith('data:') ||
-             attributes[j].value.toLowerCase().
-                trim().
-                startsWith('vbscript:'))) {
+        if ((attrName === 'href' || attrName === 'src')
+            && (isRiskyAttribute(attributes[j].value.toLowerCase().trim()))
+        ) {
           element.removeAttribute(attrName);
         }
       }
@@ -77,6 +70,16 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     return fragment;
+  }
+
+  /**
+   * @param {string} attrValue
+   * @returns {boolean}
+   */
+  function isRiskyAttribute(attrValue) {
+    return attrValue.startsWith('javascript:')
+        || attrValue.startsWith('data:')
+        || attrValue.startsWith('vbscript:');
   }
 
   // Function to safely serialize a DOM node to HTML string

--- a/src/popup.js
+++ b/src/popup.js
@@ -54,9 +54,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // Remove javascript: URLs
         if ((attrName === 'href' || attrName === 'src') &&
-            attributes[j].value.toLowerCase().
+            (attributes[j].value.toLowerCase().
                 trim().
-                startsWith('javascript:')) {
+                startsWith('javascript:') ||
+             attributes[j].value.toLowerCase().
+                trim().
+                startsWith('data:') ||
+             attributes[j].value.toLowerCase().
+                trim().
+                startsWith('vbscript:'))) {
           element.removeAttribute(attrName);
         }
       }


### PR DESCRIPTION
Potential fix for [https://github.com/brian978/read-in-short/security/code-scanning/3](https://github.com/brian978/read-in-short/security/code-scanning/3)

To fix the issue, the sanitization logic should be updated to check for `data:` and `vbscript:` schemes in addition to `javascript:`. This involves modifying the condition on line 57 to include these schemes. The fix ensures that any `href` or `src` attributes containing these schemes are removed, preventing malicious code injection.

**Steps to implement the fix:**
1. Update the condition on line 57 to check for `data:` and `vbscript:` schemes alongside `javascript:`.
2. Ensure the check is case-insensitive and trims any leading/trailing whitespace.
3. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
